### PR TITLE
Added dot notation in updateApplicantStatus to prevent overwriting status object

### DIFF
--- a/src/utility/firebase.js
+++ b/src/utility/firebase.js
@@ -67,8 +67,6 @@ export const updateApplicantStatus = async (userId, applicationStatus) => {
     .collection('Applicants')
     .doc(userId)
     .update({
-      status: {
-        applicationStatus,
-      },
+      'status.applicationStatus': applicationStatus,
     })
 }


### PR DESCRIPTION
## The issue
Grading an application will cause the `status` object in the applicant object to be overwritten and replaced with only the `applicationStatus` field. The deleted fields (`responded` and `attending`) are needed to display the application status on the app portal and allow hackers to RSVP. 

## What changed
Dot notation is used in the `update` method in order to update the `status` object to prevent overwrites. Doc ref can be found here: [https://firebase.google.com/docs/firestore/manage-data/add-data](url)  in the 'Update fields in nested objects' section

## How to test

1. First ensure the applicant you are using to test still has all the fields in its `status` object. If not, you can just manually add them
2. Grade the applicant on the assessment portal and save the scores
3. Check the `status` object, it should still have the fields that it had before the scores were saved
